### PR TITLE
fix: prevent dropping nodes into non-container layers

### DIFF
--- a/packages/editor/src/components/LayersPanel.tsx
+++ b/packages/editor/src/components/LayersPanel.tsx
@@ -25,7 +25,8 @@ function TreeItem({ node, depth, parentId }:{
 
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `drop-${node.id}`,
-    data: { isContainer: true, parentId: node.id }
+    data: { isContainer, parentId: node.id },
+    disabled: !isContainer
   });
 
   const style = {
@@ -45,7 +46,10 @@ function TreeItem({ node, depth, parentId }:{
   const isExpanded = expandedNodes.includes(node.id);
 
   return (
-    <div ref={setDropRef} style={{ background: isOver ? "#eef6ff" : undefined }}>
+    <div
+      ref={setDropRef}
+      style={{ background: isContainer && isOver ? "#eef6ff" : undefined }}
+    >
       <div
         ref={setNodeRef}
         {...attributes}
@@ -94,7 +98,9 @@ export function LayersPanel() {
     const activeId = String(active.id);
     const overId = String(over.id);
 
-    if (overId.startsWith("drop-")) {
+    const dropZone = overId.startsWith("drop-") && over.data.current?.isContainer;
+
+    if (dropZone) {
       const newParentId = over.data.current?.parentId as string;
       moveNode(activeId, newParentId, 0);
       return;


### PR DESCRIPTION
## Summary
- disable drop targets for non-container nodes in LayersPanel
- only move nodes when dropped on valid container zones

## Testing
- `pnpm test` (fails: Missing script: test)
- `pnpm typecheck` (fails: Cannot find module '@schema/core'...)


------
https://chatgpt.com/codex/tasks/task_e_689e361733308322980263b17669fd89