### PR TITLE
feat: add reusable UI primitives and refactor panels

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.1",
     "@schema/core": "workspace:*",
+    "@ui/core": "workspace:*",
     "nanoid": "^5.0.7",
     "react-contenteditable": "^3.3.7",
     "zustand": "^4.5.5"

--- a/packages/editor/src/components/LayersPanel.tsx
+++ b/packages/editor/src/components/LayersPanel.tsx
@@ -8,6 +8,7 @@ import {
   SortableContext, useSortable, verticalListSortingStrategy
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Panel, PanelHeader, IconButton } from "@ui/core";
 
 function TreeItem({ node, depth, parentId }:{
   node: any; depth: number; parentId: string;
@@ -60,14 +61,14 @@ function TreeItem({ node, depth, parentId }:{
         onClick={(e) => { e.stopPropagation(); selectNode(node.id); }}
       >
         {isContainer && (
-          <button
+          <IconButton
             onClick={(e) => { e.stopPropagation(); toggleExpand(node.id); }}
-            className="w-4 h-4 mr-1 text-xs border rounded bg-gray-50"
+            className="mr-1 text-xs"
             aria-label={isExpanded ? "Collapse" : "Expand"}
             title={isExpanded ? "Collapse" : "Expand"}
           >
             {isExpanded ? "−" : "+"}
-          </button>
+          </IconButton>
         )}
         <span className="mr-1">{icon || "📄"}</span>
         {name || node.type}
@@ -112,8 +113,8 @@ export function LayersPanel() {
   };
 
   return (
-    <aside className="w-64 bg-white border-l overflow-auto">
-      <h3 className="font-bold p-3 border-b">Navigation</h3>
+    <Panel side="right" className="overflow-auto">
+      <PanelHeader className="p-3 border-b">Navigation</PanelHeader>
       <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext
           items={(page.children || []).map((c: any) => c.id)}
@@ -124,6 +125,6 @@ export function LayersPanel() {
           ))}
         </SortableContext>
       </DndContext>
-    </aside>
+    </Panel>
   );
 }

--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useMemo } from "react";
 import { useEditorStore } from "../lib/store";
+import { Panel, PanelHeader, InputField } from "@ui/core";
 
 // Helper to find node by id in page tree
 function findNode(node: any, id: string | null): any {
@@ -22,10 +23,10 @@ export function PropertyPanel() {
 
   if (!selectedNode) {
     return (
-      <aside className="w-64 bg-white border-l p-3 overflow-auto">
-        <h3 className="font-bold mb-2">Properties</h3>
+      <Panel side="right" className="p-3 overflow-auto">
+        <PanelHeader className="mb-2">Properties</PanelHeader>
         <p className="text-sm text-gray-500">Select a node to edit its props.</p>
-      </aside>
+      </Panel>
     );
   }
 
@@ -33,8 +34,8 @@ export function PropertyPanel() {
   const keys = Object.keys(props);
 
   return (
-    <aside className="w-64 bg-white border-l p-3 overflow-auto">
-      <h3 className="font-bold mb-2">Properties</h3>
+    <Panel side="right" className="p-3 overflow-auto">
+      <PanelHeader className="mb-2">Properties</PanelHeader>
       {keys.length === 0 && (
         <p className="text-sm text-gray-500">No props available.</p>
       )}
@@ -43,14 +44,13 @@ export function PropertyPanel() {
           <label className="block text-sm font-medium mb-1" htmlFor={`prop-${key}`}>
             {key}
           </label>
-          <input
+          <InputField
             id={`prop-${key}`}
-            className="w-full border rounded px-2 py-1 text-sm"
             value={(props as any)[key] ?? ""}
             onChange={(e) => updateProps(selectedNode.id, { [key]: e.target.value })}
           />
         </div>
       ))}
-    </aside>
+    </Panel>
   );
 }

--- a/packages/editor/src/components/Sidebar.tsx
+++ b/packages/editor/src/components/Sidebar.tsx
@@ -3,13 +3,14 @@ import { nanoid } from "nanoid";
 import { widgetRegistry } from "../lib/widgetRegistry";
 import { useEditorStore } from "../lib/store";
 import { TemplateGallery } from "./TemplateGallery";
+import { Panel, PanelHeader } from "@ui/core";
 
 export function Sidebar() {
   const addChild = useEditorStore((s) => s.addChild);
   return (
-    <aside className="w-64 bg-white border-r p-3 space-y-3">
+    <Panel side="left" className="p-3 space-y-3">
       <div>
-        <h3 className="font-bold mb-2">Widgets</h3>
+        <PanelHeader className="mb-2">Widgets</PanelHeader>
         <div className="space-y-2">
           {Object.entries(widgetRegistry).map(([type, meta]) => (
             <button
@@ -33,7 +34,7 @@ export function Sidebar() {
       <div className="pt-2 border-t">
         <SaveLoadButtons />
       </div>
-    </aside>
+    </Panel>
   );
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,5 @@
 export * from "@ui/primitives/Button";
+export * from "@ui/primitives/Panel";
+export * from "@ui/primitives/PanelHeader";
+export * from "@ui/primitives/InputField";
+export * from "@ui/primitives/IconButton";

--- a/packages/ui/src/primitives/IconButton.tsx
+++ b/packages/ui/src/primitives/IconButton.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const IconButton: React.FC<IconButtonProps> = ({ className = "", ...props }) => {
+  return (
+    <button
+      className={`w-4 h-4 border rounded bg-gray-50 inline-flex items-center justify-center text-xs ${className}`}
+      {...props}
+    />
+  );
+};
+

--- a/packages/ui/src/primitives/InputField.tsx
+++ b/packages/ui/src/primitives/InputField.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+
+export interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const InputField: React.FC<InputFieldProps> = ({ className = "", ...props }) => {
+  return <input className={`w-full border rounded px-2 py-1 text-sm ${className}`} {...props} />;
+};
+

--- a/packages/ui/src/primitives/Panel.tsx
+++ b/packages/ui/src/primitives/Panel.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export interface PanelProps extends React.HTMLAttributes<HTMLElement> {
+  side?: "left" | "right";
+}
+
+export const Panel: React.FC<PanelProps> = ({ side, className = "", ...props }) => {
+  const border = side === "left" ? "border-r" : side === "right" ? "border-l" : "border";
+  return <aside className={`w-64 bg-white ${border} ${className}`} {...props} />;
+};
+

--- a/packages/ui/src/primitives/PanelHeader.tsx
+++ b/packages/ui/src/primitives/PanelHeader.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+
+export interface PanelHeaderProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+export const PanelHeader: React.FC<PanelHeaderProps> = ({ className = "", ...props }) => {
+  return <h3 className={`font-bold ${className}`} {...props} />;
+};
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.23)
+      '@ui/core':
+        specifier: workspace:*
+        version: link:../ui
       nanoid:
         specifier: ^5.0.7
         version: 5.1.5

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,8 @@
     "paths": {
       "@editor/*": ["packages/editor/src/*"],
       "@schema/*": ["packages/schema/src/*"],
-      "@utils/*": ["packages/utils/src/*"]
+      "@utils/*": ["packages/utils/src/*"],
+      "@ui/*": ["packages/ui/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Panel, PanelHeader, InputField, and IconButton primitives
- re-export new primitives and add @ui alias
- refactor editor panels to consume shared primitives

## Testing
- `pnpm install`
- `pnpm typecheck` *(fails: Cannot find module '@schema/core')*


------
https://chatgpt.com/codex/tasks/task_e_689ed28902908322b090a1ffe7fa1a09