### PR TITLE
fix workspace config and tsconfig path

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - "apps/*"
+  - "web"
   - "packages/*"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
     "allowJs": true,


### PR DESCRIPTION
## Summary
- update pnpm-workspace.yaml to reference web app directly
- correct web tsconfig to extend from the root base config

## Testing
- `pnpm typecheck` *(fails: Cannot find module '@editor/core' and others)*
- `pnpm install` *(fails: ERR_PNPM_FETCH_403: Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689ee874ef9c8322bd9d228c2f2af859