### PR TITLE
chore: add react type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
     "turbo": "2.5.5",
     "typescript": "5.9.2"
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "types": ["react", "react-dom"],
     "baseUrl": ".",
     "paths": {
       "@editor/*": ["packages/editor/src/*"],


### PR DESCRIPTION
## Summary
- add `@types/react` and `@types/react-dom` to workspace dev dependencies
- configure base tsconfig to include React type definitions

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Freact - 403)*
- `pnpm --filter @ui/core build`
- `pnpm --filter @schema/core build`
- `pnpm --filter @utils/core build`
- `pnpm --filter @editor/core build`


------
https://chatgpt.com/codex/tasks/task_e_689eebb0a1288322853fa5af638ac4e4