### PR TITLE
fix: import React type in widget registry

### DIFF
--- a/packages/editor/src/lib/widgetRegistry.tsx
+++ b/packages/editor/src/lib/widgetRegistry.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type React from "react";
 import HeadingWidget from "../widgets/HeadingWidget";
 import TextWidget from "../widgets/TextWidget";
 import ButtonWidget from "../widgets/ButtonWidget";


### PR DESCRIPTION
## Summary
- add React type import to widget registry

## Testing
- `node_modules/.bin/tsc -p packages/editor/tsconfig.json` *(fails: Cannot find module '@dnd-kit/core' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f07a5af6483229c3f8afe831b6935