### PR TITLE
refactor: centralize findNode helper

### DIFF
--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -2,17 +2,7 @@
 import { useMemo, type ChangeEvent } from "react";
 import { useEditorStore } from "../lib/store";
 import { Panel, PanelHeader, InputField } from "@ui/core";
-
-// Helper to find node by id in page tree
-function findNode(node: any, id: string | null): any {
-  if (!id) return null;
-  if (node.id === id) return node;
-  for (const child of node.children || []) {
-    const found = findNode(child, id);
-    if (found) return found;
-  }
-  return null;
-}
+import { findNode } from "../lib/findNode";
 
 export function PropertyPanel() {
   const page = useEditorStore((s) => s.page);

--- a/packages/editor/src/components/Sidebar.tsx
+++ b/packages/editor/src/components/Sidebar.tsx
@@ -4,17 +4,7 @@ import { widgetRegistry } from "../lib/widgetRegistry";
 import { useEditorStore } from "../lib/store";
 import { TemplateGallery } from "./TemplateGallery";
 import { Panel, PanelHeader } from "@ui/core";
-
-// Helper to find node by id in page tree
-function findNode(node: any, id: string | null): any {
-  if (!id) return null;
-  if (node.id === id) return node;
-  for (const child of node.children || []) {
-    const found = findNode(child, id);
-    if (found) return found;
-  }
-  return null;
-}
+import { findNode } from "../lib/findNode";
 
 export function Sidebar() {
   const addChild = useEditorStore((s) => s.addChild);

--- a/packages/editor/src/lib/findNode.ts
+++ b/packages/editor/src/lib/findNode.ts
@@ -1,0 +1,11 @@
+import type { PageNode } from "./store";
+
+export function findNode(node: PageNode, id: string | null): PageNode | null {
+  if (!id) return null;
+  if (node.id === id) return node;
+  for (const child of node.children || []) {
+    const found = findNode(child as PageNode, id);
+    if (found) return found;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- factor out a typed findNode helper in lib
- reuse findNode in Sidebar and PropertyPanel

## Testing
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `node_modules/.bin/tsc -p packages/editor/tsconfig.json --noEmit` *(fails: Cannot find module '@dnd-kit/core' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689f07b0befc832287cce2ebbda62357