### PR TITLE
feat: escape HTML in render helper

### DIFF
--- a/packages/utils/src/escape.ts
+++ b/packages/utils/src/escape.ts
@@ -1,0 +1,18 @@
+export function escapeHtml(input: string): string {
+  return input.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return ch;
+    }
+  });
+}

--- a/packages/utils/src/render.ts
+++ b/packages/utils/src/render.ts
@@ -1,4 +1,5 @@
 import type { TPageNode } from "@schema/core";
+import { escapeHtml } from "./escape";
 
 export function renderToHtml(node: TPageNode): string {
   const map: Record<string, string> = {
@@ -8,8 +9,8 @@ export function renderToHtml(node: TPageNode): string {
   const tag = map[node.type] ?? "div";
   const attrs = Object.entries(node.props || {})
     .filter(([k]) => !["text", "label", "children"].includes(k))
-    .map(([k, v]) => `${k}="${String(v)}"`).join(" ");
+    .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`).join(" ");
   const children = (node.children?.map(renderToHtml).join("") ?? "");
   const text = node.props?.text ?? node.props?.label ?? "";
-  return `<${tag}${attrs ? " " + attrs : ""}>${children || text}</${tag}>`;
+  return `<${tag}${attrs ? " " + attrs : ""}>${children || escapeHtml(text)}</${tag}>`;
 }

--- a/packages/utils/test/render.test.mjs
+++ b/packages/utils/test/render.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import ts from 'typescript';
+
+function loadTsModule(tsPath) {
+  const code = readFileSync(tsPath, 'utf8');
+  const { outputText } = ts.transpileModule(code, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true, importsNotUsedAsValues: 'remove' }
+  });
+  const module = { exports: {} };
+  const dirname = path.dirname(tsPath);
+  function requireTs(p) {
+    if (p.startsWith('./') || p.startsWith('../')) {
+      const resolved = path.resolve(dirname, p.endsWith('.ts') ? p : p + '.ts');
+      return loadTsModule(resolved);
+    }
+    return require(p);
+  }
+  vm.runInNewContext(outputText, { module, exports: module.exports, require: requireTs, __dirname: dirname, __filename: tsPath });
+  return module.exports;
+}
+
+const renderPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/render.ts');
+const { renderToHtml } = loadTsModule(renderPath);
+
+test('escapes text content', () => {
+  const node = { type: 'Text', props: { text: '5 > 3 & 2 < 4' } };
+  const html = renderToHtml(node);
+  assert.equal(html, '<p>5 &gt; 3 &amp; 2 &lt; 4</p>');
+});
+
+test('escapes quotes in text', () => {
+  const node = { type: 'Text', props: { text: "\"Hello\" & 'World'" } };
+  const html = renderToHtml(node);
+  assert.equal(html, '<p>&quot;Hello&quot; &amp; &#39;World&#39;</p>');
+});
+
+test('escapes attribute values', () => {
+  const node = { type: 'Button', props: { href: 'https://example.com?a=1&b=2', label: '<Click>' } };
+  const html = renderToHtml(node);
+  assert.equal(html, '<a href="https://example.com?a=1&amp;b=2">&lt;Click&gt;</a>');
+});
+
+test('escapes quotes in attributes', () => {
+  const node = { type: 'Button', props: { title: "\"Hello\" and 'World'", label: 'btn' } };
+  const html = renderToHtml(node);
+  assert.equal(html, '<a title="&quot;Hello&quot; and &#39;World&#39;">btn</a>');
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "baseUrl": ".",
     "paths": {
       "@editor/*": ["packages/editor/src/*"],
+      "@schema/core": ["packages/schema/src/index.ts"],
       "@schema/*": ["packages/schema/src/*"],
       "@utils/*": ["packages/utils/src/*"],
       "@ui/core": ["packages/ui/src/index.ts"]


### PR DESCRIPTION
## Summary
- add escapeHtml helper to sanitize text and attribute values
- use escapeHtml in renderToHtml
- cover special characters with unit tests

## Testing
- `node --test packages/utils/test/render.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689f07caa50c83229f974066167ce0ce