### PR TITLE
refactor: type EditorCanvas with TPageNode

### DIFF
--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useEditorStore } from "../lib/store";
 import { widgetRegistry } from "../lib/widgetRegistry";
+import type { TPageNode } from "@schema/core";
 
-function RenderNode({ node }: { node: any }) {
+function RenderNode({ node }: { node: TPageNode }) {
   const hoveredId = useEditorStore((s) => s.hoveredId);
   const selectedId = useEditorStore((s) => s.selectedId);
   const selectNode = useEditorStore((s) => s.selectNode);
@@ -10,7 +11,7 @@ function RenderNode({ node }: { node: any }) {
   if (node.type === "Page") {
     return (
       <div>
-        {node.children?.map((child: any) => (
+        {node.children?.map((child: TPageNode) => (
           <RenderNode key={child.id} node={child} />
         ))}
       </div>
@@ -34,7 +35,7 @@ function RenderNode({ node }: { node: any }) {
       onClick={(e) => { e.stopPropagation(); selectNode(node.id); }}
     >
       <Comp id={node.id} {...node.props}>
-        {meta.isContainer && node.children?.map((child: any) => (
+        {meta.isContainer && node.children?.map((child: TPageNode) => (
           <RenderNode key={child.id} node={child} />
         ))}
       </Comp>


### PR DESCRIPTION
## Summary
- type EditorCanvas nodes with TPageNode

## Testing
- `npx tsc -p packages/editor/tsconfig.json --noEmit`
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; Proxy response (403))*

------
https://chatgpt.com/codex/tasks/task_e_689f07c0387c8322bd3f24ed48ddea28