### PR TITLE
chore: move react type packages to dev deps

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -13,8 +13,6 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.1",
@@ -23,5 +21,9 @@
     "nanoid": "^5.0.7",
     "react-contenteditable": "^3.3.7",
     "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- move @types/react and @types/react-dom to devDependencies in editor package

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm typecheck` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689f07f76dbc8322bbea1d911f95f5e5