### PR TITLE
feat: add default widget styling props

### DIFF
--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -29,20 +29,24 @@ export function PropertyPanel() {
       {keys.length === 0 && (
         <p className="text-sm text-gray-500">No props available.</p>
       )}
-      {keys.map((key) => (
-        <div key={key} className="mb-2">
-          <label className="block text-sm font-medium mb-1" htmlFor={`prop-${key}`}>
-            {key}
-          </label>
-          <InputField
-            id={`prop-${key}`}
-            value={(props as any)[key] ?? ""}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              updateProps(selectedNode.id, { [key]: e.target.value })
-            }
-          />
-        </div>
-      ))}
+      {keys.map((key) => {
+        const type = key.toLowerCase().includes("color") ? "color" : "text";
+        return (
+          <div key={key} className="mb-2">
+            <label className="block text-sm font-medium mb-1" htmlFor={`prop-${key}`}>
+              {key}
+            </label>
+            <InputField
+              id={`prop-${key}`}
+              type={type}
+              value={(props as any)[key] ?? ""}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateProps(selectedNode.id, { [key]: e.target.value })
+              }
+            />
+          </div>
+        );
+      })}
     </Panel>
   );
 }

--- a/packages/editor/src/lib/widgetRegistry.tsx
+++ b/packages/editor/src/lib/widgetRegistry.tsx
@@ -17,29 +17,62 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
   Section: {
     component: SectionWidget,
     name: "Section",
-    defaultProps: {},
+    defaultProps: {
+      padding: "16px",
+      backgroundColor: "#f3f4f6",
+    },
     isContainer: true,
-    icon: "📦"
+    icon: "📦",
   },
   Heading: {
     component: HeadingWidget,
     name: "Heading",
-    defaultProps: { text: "Heading Text" },
+    defaultProps: {
+      text: "Heading Text",
+      padding: "8px 0",
+      color: "#333333",
+      fontSize: "32px",
+      backgroundColor: "transparent",
+      textAlign: "left",
+      fontWeight: "700",
+      fontFamily: "Inter, sans-serif",
+      lineHeight: "1.2em",
+    },
     isContainer: false,
-    icon: "🔠"
+    icon: "🔠",
   },
   Text: {
     component: TextWidget,
     name: "Text",
-    defaultProps: { text: "Edit me" },
+    defaultProps: {
+      text: "Edit me",
+      padding: "8px",
+      color: "#333333",
+      fontSize: "16px",
+      backgroundColor: "transparent",
+      textAlign: "left",
+      fontWeight: "400",
+      fontFamily: "Inter, sans-serif",
+      lineHeight: "1.5em",
+    },
     isContainer: false,
-    icon: "✏️"
+    icon: "✏️",
   },
   Button: {
     component: ButtonWidget,
     name: "Button",
-    defaultProps: { label: "Click Me", href: "#" },
+    defaultProps: {
+      label: "Click Me",
+      href: "#",
+      padding: "12px 24px",
+      color: "#ffffff",
+      fontSize: "16px",
+      backgroundColor: "#3b82f6",
+      borderRadius: "8px",
+      fontWeight: "700",
+      fontFamily: "Inter, sans-serif",
+    },
     isContainer: false,
-    icon: "🔘"
-  }
+    icon: "🔘",
+  },
 };

--- a/packages/editor/src/react-contenteditable.d.ts
+++ b/packages/editor/src/react-contenteditable.d.ts
@@ -1,0 +1,1 @@
+declare module "react-contenteditable";

--- a/packages/editor/src/widgets/ButtonWidget.tsx
+++ b/packages/editor/src/widgets/ButtonWidget.tsx
@@ -1,14 +1,46 @@
 "use client";
 import { useEditorStore } from "../lib/store";
 
-interface ButtonWidgetProps { id: string; label: string; href: string; }
-export default function ButtonWidget({ id, label, href }: ButtonWidgetProps) {
-  const updateProps = useEditorStore((s) => s.updateProps);
+interface ButtonWidgetProps {
+  id: string;
+  label: string;
+  href: string;
+  padding?: string;
+  color?: string;
+  fontSize?: string;
+  backgroundColor?: string;
+  borderRadius?: string;
+  fontWeight?: string;
+  fontFamily?: string;
+}
+
+export default function ButtonWidget({
+  id,
+  label,
+  href,
+  padding,
+  color,
+  fontSize,
+  backgroundColor,
+  borderRadius,
+  fontWeight,
+  fontFamily
+}: ButtonWidgetProps) {
+  const updateProps = useEditorStore((state: any) => state.updateProps);
   return (
     <a
       href={href}
       onClick={(e) => e.preventDefault()}
-      className="inline-block px-4 py-2 bg-blue-600 text-white rounded"
+      className="inline-block"
+      style={{
+        padding,
+        color,
+        fontSize,
+        backgroundColor,
+        borderRadius,
+        fontWeight,
+        fontFamily
+      }}
       onDoubleClick={() => {
         const next = prompt("Button label:", label);
         if (next !== null) updateProps(id, { label: next });

--- a/packages/editor/src/widgets/HeadingWidget.tsx
+++ b/packages/editor/src/widgets/HeadingWidget.tsx
@@ -2,15 +2,48 @@
 import ContentEditable from "react-contenteditable";
 import { useEditorStore } from "../lib/store";
 
-interface HeadingWidgetProps { id: string; text: string; }
-export default function HeadingWidget({ id, text }: HeadingWidgetProps) {
-  const updateProps = useEditorStore((s) => s.updateProps);
+interface HeadingWidgetProps {
+  id: string;
+  text: string;
+  padding?: string;
+  color?: string;
+  fontSize?: string;
+  backgroundColor?: string;
+  textAlign?: string;
+  fontWeight?: string;
+  fontFamily?: string;
+  lineHeight?: string;
+}
+
+export default function HeadingWidget({
+  id,
+  text,
+  padding,
+  color,
+  fontSize,
+  backgroundColor,
+  textAlign,
+  fontWeight,
+  fontFamily,
+  lineHeight
+}: HeadingWidgetProps) {
+  const updateProps = useEditorStore((state: any) => state.updateProps);
   return (
     <ContentEditable
       html={text}
-      onChange={(e) => updateProps(id, { text: e.currentTarget.innerHTML })}
+      onChange={(e: any) => updateProps(id, { text: e.currentTarget.innerHTML })}
       tagName="h1"
-      className="text-3xl font-bold"
+      className="outline-none"
+      style={{
+        padding,
+        color,
+        fontSize,
+        backgroundColor,
+        textAlign,
+        fontWeight,
+        fontFamily,
+        lineHeight
+      }}
     />
   );
 }

--- a/packages/editor/src/widgets/SectionWidget.tsx
+++ b/packages/editor/src/widgets/SectionWidget.tsx
@@ -4,7 +4,18 @@ import * as React from "react";
 interface SectionWidgetProps {
   id?: string;
   children?: React.ReactNode;
+  padding?: string;
+  backgroundColor?: string;
 }
-export default function SectionWidget({ children }: SectionWidgetProps) {
-  return <section className="p-4 bg-gray-100 border min-h-[48px]">{children}</section>;
+
+export default function SectionWidget({
+  children,
+  padding,
+  backgroundColor
+}: SectionWidgetProps) {
+  return (
+    <section className="border min-h-[48px]" style={{ padding, backgroundColor }}>
+      {children}
+    </section>
+  );
 }

--- a/packages/editor/src/widgets/TextWidget.tsx
+++ b/packages/editor/src/widgets/TextWidget.tsx
@@ -2,15 +2,48 @@
 import ContentEditable from "react-contenteditable";
 import { useEditorStore } from "../lib/store";
 
-interface TextWidgetProps { id: string; text: string; }
-export default function TextWidget({ id, text }: TextWidgetProps) {
-  const updateProps = useEditorStore((s) => s.updateProps);
+interface TextWidgetProps {
+  id: string;
+  text: string;
+  padding?: string;
+  color?: string;
+  fontSize?: string;
+  backgroundColor?: string;
+  textAlign?: string;
+  fontWeight?: string;
+  fontFamily?: string;
+  lineHeight?: string;
+}
+
+export default function TextWidget({
+  id,
+  text,
+  padding,
+  color,
+  fontSize,
+  backgroundColor,
+  textAlign,
+  fontWeight,
+  fontFamily,
+  lineHeight
+}: TextWidgetProps) {
+  const updateProps = useEditorStore((state: any) => state.updateProps);
   return (
     <ContentEditable
       html={text}
-      onChange={(e) => updateProps(id, { text: e.currentTarget.innerHTML })}
+      onChange={(e: any) => updateProps(id, { text: e.currentTarget.innerHTML })}
       tagName="p"
-      className="text-base"
+      className="outline-none"
+      style={{
+        padding,
+        color,
+        fontSize,
+        backgroundColor,
+        textAlign,
+        fontWeight,
+        fontFamily,
+        lineHeight
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add default style props for section, heading, text and button widgets
- render color pickers in the property panel for any color prop
- declare react-contenteditable module for typechecking

## Testing
- `pnpm typecheck` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `node_modules/.bin/tsc -p packages/editor/tsconfig.json --noEmit` *(fails: Parameter 'page' implicitly has an 'any' type, and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f14cb82b4832296096ef465167a55