### PR TITLE
Sanitize text widget input

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "tsc -w -p tsconfig.json"
+    "dev": "tsc -w -p tsconfig.json",
+    "test": "vitest"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -20,10 +21,14 @@
     "@ui/core": "workspace:*",
     "nanoid": "^5.0.7",
     "react-contenteditable": "^3.3.7",
-    "zustand": "^4.5.5"
+    "zustand": "^4.5.5",
+    "dompurify": "^3.0.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0"
+    "@types/react-dom": "^18.3.0",
+    "@types/dompurify": "^3.0.2",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/packages/editor/src/widgets/TextWidget.test.ts
+++ b/packages/editor/src/widgets/TextWidget.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import DOMPurify from 'dompurify';
+
+describe('TextWidget sanitization', () => {
+  it('removes script tags from input', () => {
+    const dirty = '<img src=x onerror=alert(1)><script>alert("xss")</script>';
+    const clean = DOMPurify.sanitize(dirty);
+    expect(clean).toBe('<img src="x">');
+  });
+});

--- a/packages/editor/src/widgets/TextWidget.tsx
+++ b/packages/editor/src/widgets/TextWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import ContentEditable from "react-contenteditable";
 import { useEditorStore } from "../lib/store";
+import DOMPurify from "dompurify";
 
 interface TextWidgetProps {
   id: string;
@@ -31,7 +32,9 @@ export default function TextWidget({
   return (
     <ContentEditable
       html={text}
-      onChange={(e: any) => updateProps(id, { text: e.currentTarget.innerHTML })}
+      onChange={(e: any) =>
+        updateProps(id, { text: DOMPurify.sanitize(e.currentTarget.innerHTML) })
+      }
       tagName="p"
       className="outline-none"
       style={{

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- sanitize editable text with DOMPurify before updating state
- configure vitest and add sanitization unit test

## Testing
- `pnpm --filter @editor/core test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e08d1f883228f220b7c267d53da