### PR TITLE
feat: add props schema for widgets

### DIFF
--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -3,6 +3,7 @@ import { useMemo, type ChangeEvent } from "react";
 import { useEditorStore } from "../lib/store";
 import { Panel, PanelHeader, InputField } from "@ui/core";
 import { findNode } from "../lib/findNode";
+import { widgetRegistry } from "../lib/widgetRegistry";
 
 export function PropertyPanel() {
   const page = useEditorStore((s) => s.page);
@@ -21,7 +22,8 @@ export function PropertyPanel() {
   }
 
   const props = selectedNode.props || {};
-  const keys = Object.keys(props);
+  const schema = widgetRegistry[selectedNode.type]?.propsSchema || {};
+  const keys = Object.keys(schema);
 
   return (
     <Panel side="right" className="p-3 overflow-auto">
@@ -29,24 +31,21 @@ export function PropertyPanel() {
       {keys.length === 0 && (
         <p className="text-sm text-gray-500">No props available.</p>
       )}
-      {keys.map((key) => {
-        const type = key.toLowerCase().includes("color") ? "color" : "text";
-        return (
-          <div key={key} className="mb-2">
-            <label className="block text-sm font-medium mb-1" htmlFor={`prop-${key}`}>
-              {key}
-            </label>
-            <InputField
-              id={`prop-${key}`}
-              type={type}
-              value={(props as any)[key] ?? ""}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                updateProps(selectedNode.id, { [key]: e.target.value })
-              }
-            />
-          </div>
-        );
-      })}
+      {keys.map((key) => (
+        <div key={key} className="mb-2">
+          <label className="block text-sm font-medium mb-1" htmlFor={`prop-${key}`}>
+            {key}
+          </label>
+          <InputField
+            id={`prop-${key}`}
+            type={schema[key]}
+            value={(props as any)[key] ?? ""}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              updateProps(selectedNode.id, { [key]: e.target.value })
+            }
+          />
+        </div>
+      ))}
     </Panel>
   );
 }

--- a/packages/editor/src/lib/widgetRegistry.tsx
+++ b/packages/editor/src/lib/widgetRegistry.tsx
@@ -5,10 +5,13 @@ import TextWidget from "../widgets/TextWidget";
 import ButtonWidget from "../widgets/ButtonWidget";
 import SectionWidget from "../widgets/SectionWidget";
 
+export type WidgetPropInputType = "text" | "color";
+
 export type WidgetMeta = {
   component: React.ComponentType<any>;
   name: string;
   defaultProps: Record<string, unknown>;
+  propsSchema: Record<string, WidgetPropInputType>;
   isContainer: boolean;
   icon: string;
 };
@@ -20,6 +23,10 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     defaultProps: {
       padding: "16px",
       backgroundColor: "#f3f4f6",
+    },
+    propsSchema: {
+      padding: "text",
+      backgroundColor: "color",
     },
     isContainer: true,
     icon: "📦",
@@ -38,6 +45,17 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
       fontFamily: "Inter, sans-serif",
       lineHeight: "1.2em",
     },
+    propsSchema: {
+      text: "text",
+      padding: "text",
+      color: "color",
+      fontSize: "text",
+      backgroundColor: "color",
+      textAlign: "text",
+      fontWeight: "text",
+      fontFamily: "text",
+      lineHeight: "text",
+    },
     isContainer: false,
     icon: "🔠",
   },
@@ -55,6 +73,17 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
       fontFamily: "Inter, sans-serif",
       lineHeight: "1.5em",
     },
+    propsSchema: {
+      text: "text",
+      padding: "text",
+      color: "color",
+      fontSize: "text",
+      backgroundColor: "color",
+      textAlign: "text",
+      fontWeight: "text",
+      fontFamily: "text",
+      lineHeight: "text",
+    },
     isContainer: false,
     icon: "✏️",
   },
@@ -71,6 +100,17 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
       borderRadius: "8px",
       fontWeight: "700",
       fontFamily: "Inter, sans-serif",
+    },
+    propsSchema: {
+      label: "text",
+      href: "text",
+      padding: "text",
+      color: "color",
+      fontSize: "text",
+      backgroundColor: "color",
+      borderRadius: "text",
+      fontWeight: "text",
+      fontFamily: "text",
     },
     isContainer: false,
     icon: "🔘",


### PR DESCRIPTION
## Summary
- describe widget input types with `propsSchema`
- render property editor inputs based on widget `propsSchema`

## Testing
- `pnpm typecheck` *(fails: fetch failed for pnpm package)*
- `pnpm build` *(fails: fetch failed for pnpm package)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e09e5908322b15c5916a5fc9ca2