### PR TITLE
feat: introduce Breakpoint type for responsive support

### DIFF
--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEditorStore } from "../lib/store";
 import { widgetRegistry } from "../lib/widgetRegistry";
-import type { TPageNode } from "@schema/core";
+import type { TPageNode, Breakpoint } from "@schema/core";
 
 function RenderNode({ node }: { node: TPageNode }) {
   const hoveredId = useEditorStore((s) => s.hoveredId);
@@ -45,8 +45,12 @@ function RenderNode({ node }: { node: TPageNode }) {
 
 export function EditorCanvas() {
   const page = useEditorStore((s) => s.page);
+  const breakpoint: Breakpoint = useEditorStore((s) => s.breakpoint);
   return (
-    <main className="flex-1 overflow-auto bg-gray-50 p-6">
+    <main
+      className="flex-1 overflow-auto bg-gray-50 p-6"
+      data-breakpoint={breakpoint}
+    >
       <div className="bg-white border rounded p-6 min-h-[70vh]">
         <RenderNode node={page} />
       </div>

--- a/packages/editor/src/lib/store.ts
+++ b/packages/editor/src/lib/store.ts
@@ -1,6 +1,6 @@
 "use client";
 import { create } from "zustand";
-import type { TPageNode } from "@schema/core";
+import type { TPageNode, Breakpoint } from "@schema/core";
 
 export interface PageNode extends TPageNode {}
 
@@ -9,6 +9,7 @@ interface EditorState {
   selectedId: string | null;
   hoveredId: string | null;
   expandedNodes: string[];
+  breakpoint: Breakpoint;
   selectNode: (id: string | null) => void;
   hoverNode: (id: string | null) => void;
   toggleExpand: (id: string) => void;
@@ -16,6 +17,7 @@ interface EditorState {
   addChild: (parentId: string, node: PageNode, index?: number) => void;
   moveNode: (id: string, newParentId: string, index: number) => void;
   updateProps: (id: string, newProps: Record<string, unknown>) => void;
+  setBreakpoint: (bp: Breakpoint) => void;
 }
 
 function deepMap(node: PageNode, fn: (n: PageNode) => PageNode): PageNode {
@@ -43,6 +45,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   selectedId: null,
   hoveredId: null,
   expandedNodes: [],
+  breakpoint: "desktop",
   selectNode: (id) =>
     set((state) => {
       if (!id) return { selectedId: null };
@@ -61,6 +64,7 @@ export const useEditorStore = create<EditorState>((set) => ({
         : [...state.expandedNodes, id]
     })),
   setPage: (page) => set({ page }),
+  setBreakpoint: (bp) => set({ breakpoint: bp }),
 
   addChild: (parentId, node, index = 0) =>
     set((state) => {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,1 +1,3 @@
-export * from "./types";
+export { PageNode, PageSchema } from "./types";
+export type { TPageNode, Breakpoint } from "./types";
+

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export type Breakpoint = "desktop" | "tablet" | "mobile";
+
 export const PageNode = z.lazy((): z.ZodTypeAny =>
   z.object({
     id: z.string(),

--- a/packages/utils/src/render.ts
+++ b/packages/utils/src/render.ts
@@ -1,7 +1,7 @@
-import type { TPageNode } from "@schema/core";
+import type { TPageNode, Breakpoint } from "@schema/core";
 import { escapeHtml } from "./escape";
 
-export function renderToHtml(node: TPageNode): string {
+export function renderToHtml(node: TPageNode, breakpoint: Breakpoint = "desktop"): string {
   const map: Record<string, string> = {
     Page: "div", Section: "section", Row: "div", Column: "div",
     Heading: "h1", Text: "p", Button: "a"
@@ -10,7 +10,9 @@ export function renderToHtml(node: TPageNode): string {
   const attrs = Object.entries(node.props || {})
     .filter(([k]) => !["text", "label", "children"].includes(k))
     .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`).join(" ");
-  const children = (node.children?.map(renderToHtml).join("") ?? "");
+  const children = (
+    node.children?.map((child: TPageNode) => renderToHtml(child, breakpoint)).join("") ?? ""
+  );
   const text = node.props?.text ?? node.props?.label ?? "";
   return `<${tag}${attrs ? " " + attrs : ""}>${children || escapeHtml(text)}</${tag}>`;
 }


### PR DESCRIPTION
## Summary
- add `Breakpoint` type to schema and re-export
- wire Breakpoint into editor store and canvas
- extend HTML renderer with breakpoint parameter

## Testing
- `npx tsc -p packages/schema/tsconfig.json`
- `npx tsc -p packages/utils/tsconfig.json`
- `node packages/utils/test/render.test.mjs`
- `npx tsc -p packages/editor/tsconfig.json` *(fails: Cannot find module '@schema/core', missing deps)*
- `npx vitest run -c packages/editor/vitest.config.ts` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_689f289e0d5c8322aa5707c99dda7fe8