### PR TITLE
feat: add responsive breakpoints

### DIFF
--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../lib/store";
+import { useEditorStore, type Breakpoint } from "../lib/store";
 import { widgetRegistry } from "../lib/widgetRegistry";
 import type { TPageNode } from "@schema/core";
 
@@ -45,9 +45,33 @@ function RenderNode({ node }: { node: TPageNode }) {
 
 export function EditorCanvas() {
   const page = useEditorStore((s) => s.page);
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+  const setActiveBreakpoint = useEditorStore((s) => s.setActiveBreakpoint);
+
+  const widths: Record<Breakpoint, string> = {
+    desktop: "max-w-full",
+    tablet: "max-w-3xl",
+    mobile: "max-w-sm"
+  };
+
   return (
     <main className="flex-1 overflow-auto bg-gray-50 p-6">
-      <div className="bg-white border rounded p-6 min-h-[70vh]">
+      <div className="mb-4 space-x-2">
+        {(["desktop", "tablet", "mobile"] as Breakpoint[]).map((bp) => (
+          <button
+            key={bp}
+            className={`px-2 py-1 border rounded ${
+              activeBreakpoint === bp ? "bg-gray-200" : ""
+            }`}
+            onClick={() => setActiveBreakpoint(bp)}
+          >
+            {bp}
+          </button>
+        ))}
+      </div>
+      <div
+        className={`bg-white border rounded p-6 min-h-[70vh] mx-auto ${widths[activeBreakpoint]}`}
+      >
         <RenderNode node={page} />
       </div>
     </main>

--- a/packages/editor/src/widgets/ButtonWidget.tsx
+++ b/packages/editor/src/widgets/ButtonWidget.tsx
@@ -1,17 +1,17 @@
 "use client";
-import { useEditorStore } from "../lib/store";
+import { useEditorStore, type Breakpoint } from "../lib/store";
 
 interface ButtonWidgetProps {
   id: string;
   label: string;
   href: string;
-  padding?: string;
-  color?: string;
-  fontSize?: string;
-  backgroundColor?: string;
-  borderRadius?: string;
-  fontWeight?: string;
-  fontFamily?: string;
+  padding?: string | Partial<Record<Breakpoint, string>>;
+  color?: string | Partial<Record<Breakpoint, string>>;
+  fontSize?: string | Partial<Record<Breakpoint, string>>;
+  backgroundColor?: string | Partial<Record<Breakpoint, string>>;
+  borderRadius?: string | Partial<Record<Breakpoint, string>>;
+  fontWeight?: string | Partial<Record<Breakpoint, string>>;
+  fontFamily?: string | Partial<Record<Breakpoint, string>>;
 }
 
 export default function ButtonWidget({
@@ -27,19 +27,25 @@ export default function ButtonWidget({
   fontFamily
 }: ButtonWidgetProps) {
   const updateProps = useEditorStore((state: any) => state.updateProps);
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+
+  const resolve = (
+    prop?: string | Partial<Record<Breakpoint, string>>
+  ): string | undefined =>
+    prop && typeof prop === "object" ? prop[activeBreakpoint] : prop;
   return (
     <a
       href={href}
       onClick={(e) => e.preventDefault()}
       className="inline-block"
       style={{
-        padding,
-        color,
-        fontSize,
-        backgroundColor,
-        borderRadius,
-        fontWeight,
-        fontFamily
+        padding: resolve(padding),
+        color: resolve(color),
+        fontSize: resolve(fontSize),
+        backgroundColor: resolve(backgroundColor),
+        borderRadius: resolve(borderRadius),
+        fontWeight: resolve(fontWeight),
+        fontFamily: resolve(fontFamily)
       }}
       onDoubleClick={() => {
         const next = prompt("Button label:", label);

--- a/packages/editor/src/widgets/HeadingWidget.tsx
+++ b/packages/editor/src/widgets/HeadingWidget.tsx
@@ -1,18 +1,18 @@
 "use client";
 import ContentEditable from "react-contenteditable";
-import { useEditorStore } from "../lib/store";
+import { useEditorStore, type Breakpoint } from "../lib/store";
 
 interface HeadingWidgetProps {
   id: string;
   text: string;
-  padding?: string;
-  color?: string;
-  fontSize?: string;
-  backgroundColor?: string;
-  textAlign?: string;
-  fontWeight?: string;
-  fontFamily?: string;
-  lineHeight?: string;
+  padding?: string | Partial<Record<Breakpoint, string>>;
+  color?: string | Partial<Record<Breakpoint, string>>;
+  fontSize?: string | Partial<Record<Breakpoint, string>>;
+  backgroundColor?: string | Partial<Record<Breakpoint, string>>;
+  textAlign?: string | Partial<Record<Breakpoint, string>>;
+  fontWeight?: string | Partial<Record<Breakpoint, string>>;
+  fontFamily?: string | Partial<Record<Breakpoint, string>>;
+  lineHeight?: string | Partial<Record<Breakpoint, string>>;
 }
 
 export default function HeadingWidget({
@@ -28,6 +28,12 @@ export default function HeadingWidget({
   lineHeight
 }: HeadingWidgetProps) {
   const updateProps = useEditorStore((state: any) => state.updateProps);
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+
+  const resolve = (
+    prop?: string | Partial<Record<Breakpoint, string>>
+  ): string | undefined =>
+    prop && typeof prop === "object" ? prop[activeBreakpoint] : prop;
   return (
     <ContentEditable
       html={text}
@@ -35,14 +41,14 @@ export default function HeadingWidget({
       tagName="h1"
       className="outline-none"
       style={{
-        padding,
-        color,
-        fontSize,
-        backgroundColor,
-        textAlign,
-        fontWeight,
-        fontFamily,
-        lineHeight
+        padding: resolve(padding),
+        color: resolve(color),
+        fontSize: resolve(fontSize),
+        backgroundColor: resolve(backgroundColor),
+        textAlign: resolve(textAlign),
+        fontWeight: resolve(fontWeight),
+        fontFamily: resolve(fontFamily),
+        lineHeight: resolve(lineHeight)
       }}
     />
   );

--- a/packages/editor/src/widgets/SectionWidget.tsx
+++ b/packages/editor/src/widgets/SectionWidget.tsx
@@ -1,11 +1,12 @@
 "use client";
 import * as React from "react";
+import { useEditorStore, type Breakpoint } from "../lib/store";
 
 interface SectionWidgetProps {
   id?: string;
   children?: React.ReactNode;
-  padding?: string;
-  backgroundColor?: string;
+  padding?: string | Partial<Record<Breakpoint, string>>;
+  backgroundColor?: string | Partial<Record<Breakpoint, string>>;
 }
 
 export default function SectionWidget({
@@ -13,8 +14,18 @@ export default function SectionWidget({
   padding,
   backgroundColor
 }: SectionWidgetProps) {
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+
+  const resolve = (
+    prop?: string | Partial<Record<Breakpoint, string>>
+  ): string | undefined =>
+    prop && typeof prop === "object" ? prop[activeBreakpoint] : prop;
+
   return (
-    <section className="border min-h-[48px]" style={{ padding, backgroundColor }}>
+    <section
+      className="border min-h-[48px]"
+      style={{ padding: resolve(padding), backgroundColor: resolve(backgroundColor) }}
+    >
       {children}
     </section>
   );

--- a/packages/editor/src/widgets/TextWidget.tsx
+++ b/packages/editor/src/widgets/TextWidget.tsx
@@ -1,19 +1,19 @@
 "use client";
 import ContentEditable from "react-contenteditable";
-import { useEditorStore } from "../lib/store";
+import { useEditorStore, type Breakpoint } from "../lib/store";
 import DOMPurify from "dompurify";
 
 interface TextWidgetProps {
   id: string;
   text: string;
-  padding?: string;
-  color?: string;
-  fontSize?: string;
-  backgroundColor?: string;
-  textAlign?: string;
-  fontWeight?: string;
-  fontFamily?: string;
-  lineHeight?: string;
+  padding?: string | Partial<Record<Breakpoint, string>>;
+  color?: string | Partial<Record<Breakpoint, string>>;
+  fontSize?: string | Partial<Record<Breakpoint, string>>;
+  backgroundColor?: string | Partial<Record<Breakpoint, string>>;
+  textAlign?: string | Partial<Record<Breakpoint, string>>;
+  fontWeight?: string | Partial<Record<Breakpoint, string>>;
+  fontFamily?: string | Partial<Record<Breakpoint, string>>;
+  lineHeight?: string | Partial<Record<Breakpoint, string>>;
 }
 
 export default function TextWidget({
@@ -29,6 +29,12 @@ export default function TextWidget({
   lineHeight
 }: TextWidgetProps) {
   const updateProps = useEditorStore((state: any) => state.updateProps);
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
+
+  const resolve = (
+    prop?: string | Partial<Record<Breakpoint, string>>
+  ): string | undefined =>
+    prop && typeof prop === "object" ? prop[activeBreakpoint] : prop;
   return (
     <ContentEditable
       html={text}
@@ -38,14 +44,14 @@ export default function TextWidget({
       tagName="p"
       className="outline-none"
       style={{
-        padding,
-        color,
-        fontSize,
-        backgroundColor,
-        textAlign,
-        fontWeight,
-        fontFamily,
-        lineHeight
+        padding: resolve(padding),
+        color: resolve(color),
+        fontSize: resolve(fontSize),
+        backgroundColor: resolve(backgroundColor),
+        textAlign: resolve(textAlign),
+        fontWeight: resolve(fontWeight),
+        fontFamily: resolve(fontFamily),
+        lineHeight: resolve(lineHeight)
       }}
     />
   );


### PR DESCRIPTION
## Summary
- add active breakpoint state and setter
- allow widgets to resolve responsive style props
- add editor controls to switch breakpoints

## Testing
- `pnpm test --filter @editor/core` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `npx vitest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx tsc -p packages/editor/tsconfig.json` *(fails: Cannot find module 'zustand' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689f28bc49448322a3353204dcf0835c