### PR TITLE
feat: add responsive layout with rows and columns

### DIFF
--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -2,11 +2,13 @@
 import { useEditorStore } from "../lib/store";
 import { widgetRegistry } from "../lib/widgetRegistry";
 import type { TPageNode } from "@schema/core";
+import { ViewportSwitcher } from "./ViewportSwitcher";
 
 function RenderNode({ node }: { node: TPageNode }) {
   const hoveredId = useEditorStore((s) => s.hoveredId);
   const selectedId = useEditorStore((s) => s.selectedId);
   const selectNode = useEditorStore((s) => s.selectNode);
+  const viewport = useEditorStore((s) => s.viewport);
 
   if (node.type === "Page") {
     return (
@@ -21,6 +23,10 @@ function RenderNode({ node }: { node: TPageNode }) {
   const meta = widgetRegistry[node.type];
   if (!meta) return null;
   const Comp = meta.component;
+  const mergedProps = {
+    ...(node.props?.desktop || {}),
+    ...(viewport !== "desktop" ? node.props?.[viewport] || {} : {})
+  } as any;
 
   const border =
     node.id === selectedId
@@ -34,7 +40,7 @@ function RenderNode({ node }: { node: TPageNode }) {
       className={`${border} relative`}
       onClick={(e) => { e.stopPropagation(); selectNode(node.id); }}
     >
-      <Comp id={node.id} {...node.props}>
+      <Comp id={node.id} {...mergedProps}>
         {meta.isContainer && node.children?.map((child: TPageNode) => (
           <RenderNode key={child.id} node={child} />
         ))}
@@ -45,10 +51,20 @@ function RenderNode({ node }: { node: TPageNode }) {
 
 export function EditorCanvas() {
   const page = useEditorStore((s) => s.page);
+  const viewport = useEditorStore((s) => s.viewport);
+  const widthClass =
+    viewport === "desktop"
+      ? "w-[1024px]"
+      : viewport === "tablet"
+      ? "w-[768px]"
+      : "w-[375px]";
   return (
     <main className="flex-1 overflow-auto bg-gray-50 p-6">
-      <div className="bg-white border rounded p-6 min-h-[70vh]">
-        <RenderNode node={page} />
+      <ViewportSwitcher />
+      <div className={`mx-auto ${widthClass}`}>
+        <div className="bg-white border rounded p-6 min-h-[70vh]">
+          <RenderNode node={page} />
+        </div>
       </div>
     </main>
   );

--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -9,6 +9,7 @@ export function PropertyPanel() {
   const page = useEditorStore((s) => s.page);
   const selectedId = useEditorStore((s) => s.selectedId);
   const updateProps = useEditorStore((s) => s.updateProps);
+  const viewport = useEditorStore((s) => s.viewport);
 
   const selectedNode = useMemo(() => findNode(page, selectedId), [page, selectedId]);
 
@@ -21,7 +22,8 @@ export function PropertyPanel() {
     );
   }
 
-  const props = selectedNode.props || {};
+  const props = (selectedNode.props as any)[viewport] || {};
+  const baseProps = (selectedNode.props as any).desktop || {};
   const schema = widgetRegistry[selectedNode.type]?.propsSchema || {};
   const keys = Object.keys(schema);
 
@@ -39,7 +41,7 @@ export function PropertyPanel() {
           <InputField
             id={`prop-${key}`}
             type={schema[key]}
-            value={(props as any)[key] ?? ""}
+            value={(props as any)[key] ?? (baseProps as any)[key] ?? ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               updateProps(selectedNode.id, { [key]: e.target.value })
             }

--- a/packages/editor/src/components/Sidebar.tsx
+++ b/packages/editor/src/components/Sidebar.tsx
@@ -31,7 +31,7 @@ export function Sidebar() {
                   {
                     id: nanoid(),
                     type,
-                    props: meta.defaultProps,
+                    props: JSON.parse(JSON.stringify(meta.defaultProps)),
                     children: meta.isContainer ? [] : undefined
                   } as any,
                   (container.children?.length || 0)

--- a/packages/editor/src/components/TemplateGallery.tsx
+++ b/packages/editor/src/components/TemplateGallery.tsx
@@ -11,16 +11,16 @@ export function TemplateGallery() {
       json: {
         id: "root",
         type: "Page",
-        props: {},
+        props: { desktop: {} },
         children: [
           {
             id: nanoid(),
             type: "Section",
-            props: {},
+            props: { desktop: {} },
             children: [
-              { id: nanoid(), type: "Heading", props: { text: "Welcome to My Site" } },
-              { id: nanoid(), type: "Text", props: { text: "Build pages visually." } },
-              { id: nanoid(), type: "Button", props: { label: "Get Started", href: "#" } }
+              { id: nanoid(), type: "Heading", props: { desktop: { text: "Welcome to My Site" } } },
+              { id: nanoid(), type: "Text", props: { desktop: { text: "Build pages visually." } } },
+              { id: nanoid(), type: "Button", props: { desktop: { label: "Get Started", href: "#" } } }
             ]
           }
         ]
@@ -31,10 +31,10 @@ export function TemplateGallery() {
       json: {
         id: "root",
         type: "Page",
-        props: {},
+        props: { desktop: {} },
         children: [
-          { id: nanoid(), type: "Section", props: {}, children: [
-            { id: nanoid(), type: "Text", props: { text: "Hello world" } }
+          { id: nanoid(), type: "Section", props: { desktop: {} }, children: [
+            { id: nanoid(), type: "Text", props: { desktop: { text: "Hello world" } } }
           ]}
         ]
       }

--- a/packages/editor/src/components/ViewportSwitcher.tsx
+++ b/packages/editor/src/components/ViewportSwitcher.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEditorStore } from "../lib/store";
+
+export function ViewportSwitcher() {
+  const viewport = useEditorStore((s) => s.viewport);
+  const setViewport = useEditorStore((s) => s.setViewport);
+  const options: ("desktop" | "tablet" | "mobile")[] = [
+    "desktop",
+    "tablet",
+    "mobile"
+  ];
+  return (
+    <div className="flex space-x-2 mb-4">
+      {options.map((v) => (
+        <button
+          key={v}
+          className={`px-2 py-1 border rounded ${
+            viewport === v ? "bg-gray-200" : ""
+          }`}
+          onClick={() => setViewport(v)}
+        >
+          {v.charAt(0).toUpperCase() + v.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}
+

--- a/packages/editor/src/lib/widgetRegistry.tsx
+++ b/packages/editor/src/lib/widgetRegistry.tsx
@@ -4,6 +4,8 @@ import HeadingWidget from "../widgets/HeadingWidget";
 import TextWidget from "../widgets/TextWidget";
 import ButtonWidget from "../widgets/ButtonWidget";
 import SectionWidget from "../widgets/SectionWidget";
+import RowWidget from "../widgets/RowWidget";
+import ColumnWidget from "../widgets/ColumnWidget";
 
 export type WidgetPropInputType = "text" | "color";
 
@@ -21,29 +23,63 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     component: SectionWidget,
     name: "Section",
     defaultProps: {
-      padding: "16px",
-      backgroundColor: "#f3f4f6",
+      desktop: {
+        padding: "16px",
+        backgroundColor: "#f3f4f6",
+        layout: "contained",
+      },
     },
     propsSchema: {
       padding: "text",
       backgroundColor: "color",
+      layout: "text",
     },
     isContainer: true,
     icon: "📦",
+  },
+  Row: {
+    component: RowWidget,
+    name: "Row",
+    defaultProps: {
+      desktop: {
+        gap: "0px",
+      },
+    },
+    propsSchema: {
+      gap: "text",
+    },
+    isContainer: true,
+    icon: "📏",
+  },
+  Column: {
+    component: ColumnWidget,
+    name: "Column",
+    defaultProps: {
+      desktop: {
+        width: "100%",
+      },
+    },
+    propsSchema: {
+      width: "text",
+    },
+    isContainer: true,
+    icon: "⬜",
   },
   Heading: {
     component: HeadingWidget,
     name: "Heading",
     defaultProps: {
-      text: "Heading Text",
-      padding: "8px 0",
-      color: "#333333",
-      fontSize: "32px",
-      backgroundColor: "transparent",
-      textAlign: "left",
-      fontWeight: "700",
-      fontFamily: "Inter, sans-serif",
-      lineHeight: "1.2em",
+      desktop: {
+        text: "Heading Text",
+        padding: "8px 0",
+        color: "#333333",
+        fontSize: "32px",
+        backgroundColor: "transparent",
+        textAlign: "left",
+        fontWeight: "700",
+        fontFamily: "Inter, sans-serif",
+        lineHeight: "1.2em",
+      },
     },
     propsSchema: {
       text: "text",
@@ -63,15 +99,17 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     component: TextWidget,
     name: "Text",
     defaultProps: {
-      text: "Edit me",
-      padding: "8px",
-      color: "#333333",
-      fontSize: "16px",
-      backgroundColor: "transparent",
-      textAlign: "left",
-      fontWeight: "400",
-      fontFamily: "Inter, sans-serif",
-      lineHeight: "1.5em",
+      desktop: {
+        text: "Edit me",
+        padding: "8px",
+        color: "#333333",
+        fontSize: "16px",
+        backgroundColor: "transparent",
+        textAlign: "left",
+        fontWeight: "400",
+        fontFamily: "Inter, sans-serif",
+        lineHeight: "1.5em",
+      },
     },
     propsSchema: {
       text: "text",
@@ -91,15 +129,17 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     component: ButtonWidget,
     name: "Button",
     defaultProps: {
-      label: "Click Me",
-      href: "#",
-      padding: "12px 24px",
-      color: "#ffffff",
-      fontSize: "16px",
-      backgroundColor: "#3b82f6",
-      borderRadius: "8px",
-      fontWeight: "700",
-      fontFamily: "Inter, sans-serif",
+      desktop: {
+        label: "Click Me",
+        href: "#",
+        padding: "12px 24px",
+        color: "#ffffff",
+        fontSize: "16px",
+        backgroundColor: "#3b82f6",
+        borderRadius: "8px",
+        fontWeight: "700",
+        fontFamily: "Inter, sans-serif",
+      },
     },
     propsSchema: {
       label: "text",

--- a/packages/editor/src/widgets/ColumnWidget.tsx
+++ b/packages/editor/src/widgets/ColumnWidget.tsx
@@ -1,0 +1,17 @@
+"use client";
+import * as React from "react";
+
+interface ColumnWidgetProps {
+  id?: string;
+  children?: React.ReactNode;
+  width?: string;
+}
+
+export default function ColumnWidget({ children, width }: ColumnWidgetProps) {
+  return (
+    <div className="min-h-[24px]" style={{ width }}>
+      {children}
+    </div>
+  );
+}
+

--- a/packages/editor/src/widgets/RowWidget.tsx
+++ b/packages/editor/src/widgets/RowWidget.tsx
@@ -1,0 +1,17 @@
+"use client";
+import * as React from "react";
+
+interface RowWidgetProps {
+  id?: string;
+  children?: React.ReactNode;
+  gap?: string;
+}
+
+export default function RowWidget({ children, gap }: RowWidgetProps) {
+  return (
+    <div className="flex" style={{ gap }}>
+      {children}
+    </div>
+  );
+}
+

--- a/packages/editor/src/widgets/SectionWidget.tsx
+++ b/packages/editor/src/widgets/SectionWidget.tsx
@@ -6,16 +6,24 @@ interface SectionWidgetProps {
   children?: React.ReactNode;
   padding?: string;
   backgroundColor?: string;
+  layout?: string;
 }
 
 export default function SectionWidget({
   children,
   padding,
-  backgroundColor
+  backgroundColor,
+  layout
 }: SectionWidgetProps) {
+  const content =
+    layout === "contained" ? (
+      <div className="max-w-[1200px] mx-auto">{children}</div>
+    ) : (
+      children
+    );
   return (
     <section className="border min-h-[48px]" style={{ padding, backgroundColor }}>
-      {children}
+      {content}
     </section>
   );
 }

--- a/packages/utils/src/render.ts
+++ b/packages/utils/src/render.ts
@@ -7,10 +7,11 @@ export function renderToHtml(node: TPageNode): string {
     Heading: "h1", Text: "p", Button: "a"
   };
   const tag = map[node.type] ?? "div";
-  const attrs = Object.entries(node.props || {})
+  const props = (node.props as any)?.desktop || {};
+  const attrs = Object.entries(props)
     .filter(([k]) => !["text", "label", "children"].includes(k))
     .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`).join(" ");
   const children = (node.children?.map(renderToHtml).join("") ?? "");
-  const text = node.props?.text ?? node.props?.label ?? "";
+  const text = (props as any)?.text ?? (props as any)?.label ?? "";
   return `<${tag}${attrs ? " " + attrs : ""}>${children || escapeHtml(text)}</${tag}>`;
 }

--- a/packages/utils/test/render.test.mjs
+++ b/packages/utils/test/render.test.mjs
@@ -9,7 +9,11 @@ import ts from 'typescript';
 function loadTsModule(tsPath) {
   const code = readFileSync(tsPath, 'utf8');
   const { outputText } = ts.transpileModule(code, {
-    compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true, importsNotUsedAsValues: 'remove' }
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      importsNotUsedAsValues: 'remove'
+    }
   });
   const module = { exports: {} };
   const dirname = path.dirname(tsPath);
@@ -20,33 +24,49 @@ function loadTsModule(tsPath) {
     }
     return require(p);
   }
-  vm.runInNewContext(outputText, { module, exports: module.exports, require: requireTs, __dirname: dirname, __filename: tsPath });
+  vm.runInNewContext(
+    outputText,
+    { module, exports: module.exports, require: requireTs, __dirname: dirname, __filename: tsPath }
+  );
   return module.exports;
 }
 
-const renderPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/render.ts');
+const renderPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/render.ts'
+);
 const { renderToHtml } = loadTsModule(renderPath);
 
 test('escapes text content', () => {
-  const node = { type: 'Text', props: { text: '5 > 3 & 2 < 4' } };
+  const node = { type: 'Text', props: { desktop: { text: '5 > 3 & 2 < 4' } } };
   const html = renderToHtml(node);
   assert.equal(html, '<p>5 &gt; 3 &amp; 2 &lt; 4</p>');
 });
 
 test('escapes quotes in text', () => {
-  const node = { type: 'Text', props: { text: "\"Hello\" & 'World'" } };
+  const node = {
+    type: 'Text',
+    props: { desktop: { text: '"Hello" & \u0027World\u0027' } }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<p>&quot;Hello&quot; &amp; &#39;World&#39;</p>');
 });
 
 test('escapes attribute values', () => {
-  const node = { type: 'Button', props: { href: 'https://example.com?a=1&b=2', label: '<Click>' } };
+  const node = {
+    type: 'Button',
+    props: { desktop: { href: 'https://example.com?a=1&b=2', label: '<Click>' } }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<a href="https://example.com?a=1&amp;b=2">&lt;Click&gt;</a>');
 });
 
 test('escapes quotes in attributes', () => {
-  const node = { type: 'Button', props: { title: "\"Hello\" and 'World'", label: 'btn' } };
+  const node = {
+    type: 'Button',
+    props: { desktop: { title: '"Hello" and \u0027World\u0027', label: 'btn' } }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<a title="&quot;Hello&quot; and &#39;World&#39;">btn</a>');
 });
+


### PR DESCRIPTION
## Summary
- add viewport-aware store and UI switcher
- support rows and columns with responsive props and default section layout toggle
- render HTML from desktop props only

## Testing
- `node packages/utils/test/render.test.mjs`
- `pnpm typecheck` *(fails: Cannot find module '@editor/core' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689f469986b48322b85e15424138e851