### PR TITLE
feat: add responsive layout with rows and columns

### DIFF
--- a/packages/editor/src/components/BreakpointSwitcher.tsx
+++ b/packages/editor/src/components/BreakpointSwitcher.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEditorStore } from "../lib/store";
+
+export function BreakpointSwitcher() {
+  const viewport = useEditorStore((s) => s.activeBreakpoint);
+  const setViewport = useEditorStore((s) => s.setActiveBreakpoint);
+  const options: ("desktop" | "tablet" | "mobile")[] = [
+    "desktop",
+    "tablet",
+    "mobile"
+  ];
+  return (
+    <div className="flex space-x-2 mb-4">
+      {options.map((v) => (
+        <button
+          key={v}
+          className={`px-2 py-1 border rounded ${
+            viewport === v ? "bg-gray-200" : ""
+          }`}
+          onClick={() => setViewport(v)}
+        >
+          {v.charAt(0).toUpperCase() + v.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}
+

--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -2,11 +2,14 @@
 import { useEditorStore } from "../lib/store";
 import { widgetRegistry } from "../lib/widgetRegistry";
 import type { TPageNode } from "@schema/core";
+import { BreakpointSwitcher } from "./BreakpointSwitcher";
+import { resolveProps } from "../lib/resolveProps";
 
 function RenderNode({ node }: { node: TPageNode }) {
   const hoveredId = useEditorStore((s) => s.hoveredId);
   const selectedId = useEditorStore((s) => s.selectedId);
   const selectNode = useEditorStore((s) => s.selectNode);
+  const activeBreakpoint = useEditorStore((s) => s.activeBreakpoint);
 
   if (node.type === "Page") {
     return (
@@ -21,6 +24,7 @@ function RenderNode({ node }: { node: TPageNode }) {
   const meta = widgetRegistry[node.type];
   if (!meta) return null;
   const Comp = meta.component;
+  const mergedProps = resolveProps(node as any, activeBreakpoint);
 
   const border =
     node.id === selectedId
@@ -34,7 +38,7 @@ function RenderNode({ node }: { node: TPageNode }) {
       className={`${border} relative`}
       onClick={(e) => { e.stopPropagation(); selectNode(node.id); }}
     >
-      <Comp id={node.id} {...node.props}>
+      <Comp id={node.id} {...mergedProps}>
         {meta.isContainer && node.children?.map((child: TPageNode) => (
           <RenderNode key={child.id} node={child} />
         ))}
@@ -45,10 +49,20 @@ function RenderNode({ node }: { node: TPageNode }) {
 
 export function EditorCanvas() {
   const page = useEditorStore((s) => s.page);
+  const viewport = useEditorStore((s) => s.activeBreakpoint);
+  const widthClass =
+    viewport === "desktop"
+      ? "w-[1024px]"
+      : viewport === "tablet"
+      ? "w-[768px]"
+      : "w-[375px]";
   return (
     <main className="flex-1 overflow-auto bg-gray-50 p-6">
-      <div className="bg-white border rounded p-6 min-h-[70vh]">
-        <RenderNode node={page} />
+      <BreakpointSwitcher />
+      <div className={`mx-auto ${widthClass}`}>
+        <div className="bg-white border rounded p-6 min-h-[70vh]">
+          <RenderNode node={page} />
+        </div>
       </div>
     </main>
   );

--- a/packages/editor/src/components/PropertyPanel.tsx
+++ b/packages/editor/src/components/PropertyPanel.tsx
@@ -4,11 +4,13 @@ import { useEditorStore } from "../lib/store";
 import { Panel, PanelHeader, InputField } from "@ui/core";
 import { findNode } from "../lib/findNode";
 import { widgetRegistry } from "../lib/widgetRegistry";
+import { resolveProps } from "../lib/resolveProps";
 
 export function PropertyPanel() {
   const page = useEditorStore((s) => s.page);
   const selectedId = useEditorStore((s) => s.selectedId);
   const updateProps = useEditorStore((s) => s.updateProps);
+  const viewport = useEditorStore((s) => s.activeBreakpoint);
 
   const selectedNode = useMemo(() => findNode(page, selectedId), [page, selectedId]);
 
@@ -21,7 +23,7 @@ export function PropertyPanel() {
     );
   }
 
-  const props = selectedNode.props || {};
+  const props = resolveProps(selectedNode as any, viewport);
   const schema = widgetRegistry[selectedNode.type]?.propsSchema || {};
   const keys = Object.keys(schema);
 

--- a/packages/editor/src/components/Sidebar.tsx
+++ b/packages/editor/src/components/Sidebar.tsx
@@ -31,7 +31,7 @@ export function Sidebar() {
                   {
                     id: nanoid(),
                     type,
-                    props: meta.defaultProps,
+                    props: JSON.parse(JSON.stringify(meta.defaultProps)),
                     children: meta.isContainer ? [] : undefined
                   } as any,
                   (container.children?.length || 0)

--- a/packages/editor/src/components/TemplateGallery.tsx
+++ b/packages/editor/src/components/TemplateGallery.tsx
@@ -9,7 +9,7 @@ export function TemplateGallery() {
     {
       name: "Hero + CTA",
       json: {
-        id: "root",
+        id: "page-root",
         type: "Page",
         props: {},
         children: [
@@ -29,7 +29,7 @@ export function TemplateGallery() {
     {
       name: "Simple Text",
       json: {
-        id: "root",
+        id: "page-root",
         type: "Page",
         props: {},
         children: [

--- a/packages/editor/src/lib/resolveProps.ts
+++ b/packages/editor/src/lib/resolveProps.ts
@@ -1,0 +1,12 @@
+import type { TPageNode } from "@schema/core";
+
+export type Breakpoint = 'desktop' | 'tablet' | 'mobile';
+
+export function resolveProps(node: TPageNode, bp: Breakpoint) {
+  const base = node.props || {};
+  const responsive = (node as any).responsive || {};
+  if (bp === 'mobile') return { ...base };
+  if (bp === 'tablet') return { ...base, ...(responsive.tablet || {}) };
+  // desktop
+  return { ...base, ...(responsive.tablet || {}), ...(responsive.desktop || {}) };
+}

--- a/packages/editor/src/lib/widgetRegistry.tsx
+++ b/packages/editor/src/lib/widgetRegistry.tsx
@@ -4,6 +4,8 @@ import HeadingWidget from "../widgets/HeadingWidget";
 import TextWidget from "../widgets/TextWidget";
 import ButtonWidget from "../widgets/ButtonWidget";
 import SectionWidget from "../widgets/SectionWidget";
+import RowWidget from "../widgets/RowWidget";
+import ColumnWidget from "../widgets/ColumnWidget";
 
 export type WidgetPropInputType = "text" | "color";
 
@@ -23,13 +25,39 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     defaultProps: {
       padding: "16px",
       backgroundColor: "#f3f4f6",
+      layoutStyle: "contained",
     },
     propsSchema: {
       padding: "text",
       backgroundColor: "color",
+      layoutStyle: "text",
     },
     isContainer: true,
     icon: "📦",
+  },
+  Row: {
+    component: RowWidget,
+    name: "Row",
+    defaultProps: {
+      gap: "0px",
+    },
+    propsSchema: {
+      gap: "text",
+    },
+    isContainer: true,
+    icon: "📏",
+  },
+  Column: {
+    component: ColumnWidget,
+    name: "Column",
+    defaultProps: {
+      span: 12,
+    },
+    propsSchema: {
+      span: "text",
+    },
+    isContainer: true,
+    icon: "⬜",
   },
   Heading: {
     component: HeadingWidget,

--- a/packages/editor/src/widgets/ButtonWidget.tsx
+++ b/packages/editor/src/widgets/ButtonWidget.tsx
@@ -45,6 +45,8 @@ export default function ButtonWidget({
         const next = prompt("Button label:", label);
         if (next !== null) updateProps(id, { label: next });
       }}
+      data-node-id={id}
+      data-node-type="Button"
     >
       {label}
     </a>

--- a/packages/editor/src/widgets/ColumnWidget.tsx
+++ b/packages/editor/src/widgets/ColumnWidget.tsx
@@ -1,0 +1,21 @@
+"use client";
+import * as React from "react";
+
+interface ColumnWidgetProps {
+  id: string;
+  children?: React.ReactNode;
+  span?: number;
+}
+
+export default function ColumnWidget({ id, children, span = 12 }: ColumnWidgetProps) {
+  return (
+    <div
+      data-node-id={id}
+      data-node-type="Column"
+      style={{ minHeight: "24px", gridColumn: `span ${span} / span ${span}` }}
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/packages/editor/src/widgets/HeadingWidget.tsx
+++ b/packages/editor/src/widgets/HeadingWidget.tsx
@@ -44,6 +44,8 @@ export default function HeadingWidget({
         fontFamily,
         lineHeight
       }}
+      data-node-id={id}
+      data-node-type="Heading"
     />
   );
 }

--- a/packages/editor/src/widgets/RowWidget.tsx
+++ b/packages/editor/src/widgets/RowWidget.tsx
@@ -1,0 +1,21 @@
+"use client";
+import * as React from "react";
+
+interface RowWidgetProps {
+  id: string;
+  children?: React.ReactNode;
+  gap?: string;
+}
+
+export default function RowWidget({ id, children, gap }: RowWidgetProps) {
+  return (
+    <div
+      data-node-id={id}
+      data-node-type="Row"
+      style={{ display: "grid", gridTemplateColumns: "repeat(12,minmax(0,1fr))", gap }}
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/packages/editor/src/widgets/SectionWidget.tsx
+++ b/packages/editor/src/widgets/SectionWidget.tsx
@@ -2,20 +2,41 @@
 import * as React from "react";
 
 interface SectionWidgetProps {
-  id?: string;
+  id: string;
   children?: React.ReactNode;
   padding?: string;
   backgroundColor?: string;
+  layoutStyle?: string;
 }
 
 export default function SectionWidget({
+  id,
   children,
   padding,
-  backgroundColor
+  backgroundColor,
+  layoutStyle = "contained",
 }: SectionWidgetProps) {
-  return (
-    <section className="border min-h-[48px]" style={{ padding, backgroundColor }}>
+  const innerStyle: React.CSSProperties = { padding };
+  const sectionStyle: React.CSSProperties = { background: backgroundColor };
+
+  const inner = (
+    <div
+      className="section__inner"
+      style={{ ...innerStyle, maxWidth: layoutStyle === "contained" ? "1200px" : "none", margin: "0 auto" }}
+    >
       {children}
+    </div>
+  );
+
+  return (
+    <section
+      data-node-id={id}
+      data-node-type="Section"
+      data-layout={layoutStyle}
+      className="min-h-[48px] border"
+      style={sectionStyle}
+    >
+      {inner}
     </section>
   );
 }

--- a/packages/editor/src/widgets/TextWidget.tsx
+++ b/packages/editor/src/widgets/TextWidget.tsx
@@ -47,6 +47,8 @@ export default function TextWidget({
         fontFamily,
         lineHeight
       }}
+      data-node-id={id}
+      data-node-type="Text"
     />
   );
 }

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,13 +1,22 @@
 import { z } from "zod";
 
-export const PageNode = z.lazy((): z.ZodTypeAny =>
+const ResponsiveProps = z
+  .object({
+    mobile: z.record(z.any()).optional(),
+    tablet: z.record(z.any()).optional(),
+    desktop: z.record(z.any()).optional(),
+  })
+  .partial();
+
+export const PageNode: z.ZodTypeAny = z.lazy(() =>
   z.object({
     id: z.string(),
     type: z.string(),
     props: z.record(z.any()).default({}),
-    children: z.array(PageNode).optional()
+    responsive: ResponsiveProps.optional(),
+    children: z.array(PageNode).optional(),
   })
 );
 
-export const PageSchema = PageNode;
 export type TPageNode = z.infer<typeof PageNode>;
+export const PageSchema = PageNode;

--- a/packages/utils/src/render.ts
+++ b/packages/utils/src/render.ts
@@ -3,14 +3,21 @@ import { escapeHtml } from "./escape";
 
 export function renderToHtml(node: TPageNode): string {
   const map: Record<string, string> = {
-    Page: "div", Section: "section", Row: "div", Column: "div",
-    Heading: "h1", Text: "p", Button: "a"
+    Page: "div",
+    Section: "section",
+    Row: "div",
+    Column: "div",
+    Heading: "h1",
+    Text: "p",
+    Button: "a",
   };
   const tag = map[node.type] ?? "div";
-  const attrs = Object.entries(node.props || {})
+  const props = (node.props as any) || {};
+  const attrs = Object.entries(props)
     .filter(([k]) => !["text", "label", "children"].includes(k))
-    .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`).join(" ");
+    .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`)
+    .join(" ");
   const children = (node.children?.map(renderToHtml).join("") ?? "");
-  const text = node.props?.text ?? node.props?.label ?? "";
+  const text = (props as any)?.text ?? (props as any)?.label ?? "";
   return `<${tag}${attrs ? " " + attrs : ""}>${children || escapeHtml(text)}</${tag}>`;
 }

--- a/packages/utils/test/render.test.mjs
+++ b/packages/utils/test/render.test.mjs
@@ -9,7 +9,11 @@ import ts from 'typescript';
 function loadTsModule(tsPath) {
   const code = readFileSync(tsPath, 'utf8');
   const { outputText } = ts.transpileModule(code, {
-    compilerOptions: { module: ts.ModuleKind.CommonJS, esModuleInterop: true, importsNotUsedAsValues: 'remove' }
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      importsNotUsedAsValues: 'remove'
+    }
   });
   const module = { exports: {} };
   const dirname = path.dirname(tsPath);
@@ -20,11 +24,17 @@ function loadTsModule(tsPath) {
     }
     return require(p);
   }
-  vm.runInNewContext(outputText, { module, exports: module.exports, require: requireTs, __dirname: dirname, __filename: tsPath });
+  vm.runInNewContext(
+    outputText,
+    { module, exports: module.exports, require: requireTs, __dirname: dirname, __filename: tsPath }
+  );
   return module.exports;
 }
 
-const renderPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/render.ts');
+const renderPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/render.ts'
+);
 const { renderToHtml } = loadTsModule(renderPath);
 
 test('escapes text content', () => {
@@ -34,19 +44,29 @@ test('escapes text content', () => {
 });
 
 test('escapes quotes in text', () => {
-  const node = { type: 'Text', props: { text: "\"Hello\" & 'World'" } };
+  const node = {
+    type: 'Text',
+    props: { text: '"Hello" & \u0027World\u0027' }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<p>&quot;Hello&quot; &amp; &#39;World&#39;</p>');
 });
 
 test('escapes attribute values', () => {
-  const node = { type: 'Button', props: { href: 'https://example.com?a=1&b=2', label: '<Click>' } };
+  const node = {
+    type: 'Button',
+    props: { href: 'https://example.com?a=1&b=2', label: '<Click>' }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<a href="https://example.com?a=1&amp;b=2">&lt;Click&gt;</a>');
 });
 
 test('escapes quotes in attributes', () => {
-  const node = { type: 'Button', props: { title: "\"Hello\" and 'World'", label: 'btn' } };
+  const node = {
+    type: 'Button',
+    props: { title: '"Hello" and \u0027World\u0027', label: 'btn' }
+  };
   const html = renderToHtml(node);
   assert.equal(html, '<a title="&quot;Hello&quot; and &#39;World&#39;">btn</a>');
 });
+


### PR DESCRIPTION
## Summary
- support breakpoint-aware props in schema and store
- add row/column grid and section layout toggle
- render nodes with merged breakpoint props

## Testing
- `node packages/utils/test/render.test.mjs`
- `pnpm typecheck` *(fails: Cannot find module '@editor/core' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689f469986b48322b85e15424138e851