### PR TITLE
feat: add drag drop widgets and preview

### DIFF
--- a/packages/editor/src/components/EditorCanvas.tsx
+++ b/packages/editor/src/components/EditorCanvas.tsx
@@ -4,6 +4,8 @@ import { widgetRegistry } from "../lib/widgetRegistry";
 import type { TPageNode } from "@schema/core";
 import { BreakpointSwitcher } from "./BreakpointSwitcher";
 import { resolveProps } from "../lib/resolveProps";
+import { DndContext, useDroppable, DragEndEvent } from "@dnd-kit/core";
+import { nanoid } from "nanoid";
 
 function RenderNode({ node }: { node: TPageNode }) {
   const hoveredId = useEditorStore((s) => s.hoveredId);
@@ -50,6 +52,26 @@ function RenderNode({ node }: { node: TPageNode }) {
 export function EditorCanvas() {
   const page = useEditorStore((s) => s.page);
   const viewport = useEditorStore((s) => s.activeBreakpoint);
+  const addChild = useEditorStore((s) => s.addChild);
+  const { setNodeRef, isOver } = useDroppable({ id: "canvas-root" });
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over?.id === "canvas-root" && active.data.current?.widgetType) {
+      const type = active.data.current.widgetType as string;
+      const meta = widgetRegistry[type];
+      addChild(
+        page.id,
+        {
+          id: nanoid(),
+          type,
+          props: JSON.parse(JSON.stringify(meta.defaultProps)),
+          children: meta.isContainer ? [] : undefined
+        } as any,
+        page.children?.length || 0
+      );
+    }
+  };
   const widthClass =
     viewport === "desktop"
       ? "w-[1024px]"
@@ -57,13 +79,20 @@ export function EditorCanvas() {
       ? "w-[768px]"
       : "w-[375px]";
   return (
-    <main className="flex-1 overflow-auto bg-gray-50 p-6">
-      <BreakpointSwitcher />
-      <div className={`mx-auto ${widthClass}`}>
-        <div className="bg-white border rounded p-6 min-h-[70vh]">
-          <RenderNode node={page} />
+    <DndContext onDragEnd={handleDragEnd}>
+      <main className="flex-1 overflow-auto bg-gray-50 p-6">
+        <BreakpointSwitcher />
+        <div className={`mx-auto ${widthClass}`}>
+          <div
+            ref={setNodeRef}
+            className={`bg-white border rounded p-6 min-h-[70vh] ${
+              isOver ? "ring-2 ring-blue-400" : ""
+            }`}
+          >
+            <RenderNode node={page} />
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </DndContext>
   );
 }

--- a/web/app/preview/page.tsx
+++ b/web/app/preview/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEffect, useState } from "react";
+import { widgetRegistry } from "@editor/lib/widgetRegistry";
+import { resolveProps } from "@editor/lib/resolveProps";
+import type { TPageNode } from "@schema/core";
+
+function RenderNode({ node }: { node: TPageNode }) {
+  if (node.type === "Page") {
+    return (
+      <div>
+        {node.children?.map((child) => (
+          <RenderNode key={child.id} node={child} />
+        ))}
+      </div>
+    );
+  }
+  const meta = widgetRegistry[node.type];
+  if (!meta) return null;
+  const Comp = meta.component as any;
+  const mergedProps = resolveProps(node as any, "desktop");
+  return (
+    <Comp id={node.id} {...mergedProps}>
+      {meta.isContainer &&
+        node.children?.map((child) => (
+          <RenderNode key={child.id} node={child} />
+        ))}
+    </Comp>
+  );
+}
+
+export default function PreviewPage() {
+  const [page, setPage] = useState<TPageNode | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("saved-page");
+    if (saved) {
+      try {
+        setPage(JSON.parse(saved));
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  if (!page) {
+    return <main className="p-6">No saved page</main>;
+  }
+
+  return (
+    <main className="p-6">
+      <RenderNode node={page} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- allow dragging widgets from sidebar onto canvas
- add preview page that shows last saved design
- persist saved pages locally for preview

## Testing
- `pnpm test -r -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689f653131e08322b726ef69e1fad33a